### PR TITLE
Allow edit password by default

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,2 +1,2 @@
 master_key:
-  allow_edit: false
+  allow_edit: true


### PR DESCRIPTION
It feels kinda weird that you can not change the master key by default.
Also before we made it possible to disable the edit; you could always change the master key.
So we swapped the default behavior.

This fixes that